### PR TITLE
bind duplicate of ports

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,11 +1,9 @@
 server {
-	listen 80 default_server;
 	listen [::]:80 default_server;
 	server_name example.com www.example.com;
 	return 301 https://example.com$request_uri;
 }
 server {
-	listen 443 ssl spdy;
 	listen [::]:443 ssl spdy;
 	server_name www.example.com;
 	ssl on;
@@ -15,8 +13,6 @@ server {
 }
 
 server {
-
-	listen 443 ssl spdy;
 	listen [::]:443 ssl spdy;
 	server_name example.com;
 	root /path/to/example.com;


### PR DESCRIPTION
Error Message:

2015/12/05 23:22:21 [emerg] 28732#28732: bind() to 0.0.0.0:443 failed (98: Address already in use)