### PR TITLE
Pass all parameters to renew_ssl

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,5 +1,5 @@
 renew-ssl() {
 	mkdir -p /tmp/letsencrypt-eustasy
-	~/letsencrypt/letsencrypt-auto certonly --config ~/letsencrypt-with-nginx/cli.ini --server https://acme-v01.api.letsencrypt.org/directory -a webroot --webroot-path=/tmp/letsencrypt-eustasy --agree-tos $1 $2 $3 $4 $5 $6 $7 $8 $9 $10
+	~/letsencrypt/letsencrypt-auto certonly --config ~/letsencrypt-with-nginx/cli.ini --server https://acme-v01.api.letsencrypt.org/directory -a webroot --webroot-path=/tmp/letsencrypt-eustasy --agree-tos "$@"
 	sudo service nginx reload
 }


### PR DESCRIPTION
I had an issue with the "$1 $2..." format, I'm not sure why, the resulting command appended a "-d0" at the end of the line, and it crashed the letsencrypt command.

I'm using this "$@" bash variable to fetch all parameters passed to renew_ssl command, and it solved my problem.